### PR TITLE
Issue with generated code mutating data types

### DIFF
--- a/test/tests/contract-codegen.ts
+++ b/test/tests/contract-codegen.ts
@@ -1,6 +1,6 @@
 import {assert} from 'chai'
 
-import {ABI, APIClient, Name} from '@wharfkit/antelope'
+import {ABI, APIClient, Name, Serializer} from '@wharfkit/antelope'
 import {makeClient} from '@wharfkit/mock-data'
 
 import fs from 'fs'
@@ -79,6 +79,67 @@ suite('codegen', async function () {
                 contracts[testCase] = generated.import
             }
         }
+    })
+
+    test('bug', async function () {
+        const data: any = {
+            requirements: {
+                team_id: [],
+                min_power: 0,
+                min_balance: 0,
+                min_stake: 0,
+                min_cumulative_team_contribution: 0,
+            },
+            actions: {
+                delegated_stake: 0,
+                stake_locked_additional_rounds: 0,
+                nft_actions: [
+                    {
+                        collection_name: 'dddd',
+                        schema_name: 'dddddd',
+                        template_id: '3',
+                        match_immutable_attributes: [
+                            {
+                                key: 'keyname',
+                                value: 'keytest',
+                            },
+                        ],
+                        match_mutable_attributes: [],
+                        burn: false,
+                        lock_rounds: 0,
+                    },
+                ],
+                balance_payment: 0,
+            },
+            rewards: {
+                nft_mints: [],
+                balance_deposit: 0,
+                delegated_stake: 0,
+                stake_locked_additional_rounds: 0,
+                activate_powermod_ids: [],
+            },
+            limits: {
+                offer_quantity_remaining: 0,
+                available_until_round: 0,
+            },
+        }
+
+        const test = Boid.Types.offeradd.from(data)
+        /**
+         * The input for `team_id` was an array and comes back as an empty string
+         */
+        assert.equal(test.requirements.team_id, data.requirements.team_id)
+        /**
+         * The value of the `actions.nft_actions[0].match_immutable_attributes[0].value` was a string and comes back as an empty object
+         */
+        assert.equal(
+            String(test.actions.nft_actions[0].match_immutable_attributes[0].value),
+            'keytest'
+        )
+        /**
+         * The input for `rewards.activated_powermod_ids` was an array and comes back as an empty string
+         */
+        assert.equal(test.rewards.activate_powermod_ids, data.rewards.activate_powermod_ids)
     })
 
     suite('Generated vs Static', function () {


### PR DESCRIPTION
This unit test illustrates a bug which is mutating some of the data and causing the wrong types to be returned. Unsure of the source. The data being input into this struct is provided in the test, and 3x asserts with comments were added to show what the expected results should be.

Conversation about this bug is here in Telegram:

https://t.me/wharfkit/2530