### PR TITLE
Fix according to atomicassets usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,16 @@ ci-test: node_modules
 test_generate: node_modules clean lib
 	node lib/cli.js generate eosio.token -u https://jungle4.greymass.com
 
+.PHONY: update_mock_contracts
+update_mock_contracts: node_modules clean lib
+	node lib/cli.js generate atomicassets -u https://jungle4.greymass.com -j test/data/abis/atomicassets.json -f test/data/contracts/mock-atomicassets.ts -e .eslintrc
+	node lib/cli.js generate boid -u https://jungle4.greymass.com -j test/data/abis/boid.json -f test/data/contracts/mock-boid.ts -e .eslintrc
+	node lib/cli.js generate eosio -u https://jungle4.greymass.com -j test/data/abis/eosio.json -f test/data/contracts/mock-eosio.ts -e .eslintrc
+	node lib/cli.js generate eosio.msig -u https://jungle4.greymass.com -j test/data/abis/eosio.msig.json -f test/data/contracts/mock-eosio.msig.ts -e .eslintrc
+	node lib/cli.js generate eosio.token -u https://jungle4.greymass.com -j test/data/abis/eosio.token.json -f test/data/contracts/mock-eosio.token.ts -e .eslintrc
+	node lib/cli.js generate hegemon.hgm -u https://jungle4.greymass.com -j test/data/abis/hegemon.hgm.json -f test/data/contracts/mock-hegemon.hgm.ts -e .eslintrc
+	node lib/cli.js generate rewards.gm -u https://jungle4.greymass.com -j test/data/abis/rewards.gm.json -f test/data/contracts/mock-rewards.gm.ts -e .eslintrc
+
 .PHONY: check
 check: node_modules
 	@${BIN}/eslint src test --ext .ts --max-warnings 0 --format unix && echo "Ok"

--- a/src/commands/contract/finders.ts
+++ b/src/commands/contract/finders.ts
@@ -17,10 +17,10 @@ export const ANTELOPE_CLASS_MAPPINGS = {
 export const ANTELOPE_CLASS_WITHOUT_TYPES = ['BlockTimestamp', 'TimePointSec']
 
 export function findTypeFromAlias(typeString: string, abi: ABI.Def): string | undefined {
-    const {type: typeStringWithoutDecorator, decorator} = extractDecorator(typeString)
+    const {type: typeStringWithoutDecorator} = extractDecorator(typeString)
     const alias = abi.types.find((type) => type.new_type_name === typeStringWithoutDecorator)
 
-    return alias?.type && `${alias?.type}${decorator || ''}`
+    return alias?.type
 }
 
 export function findAliasFromType(typeString: string, abi: ABI.Def): string | undefined {

--- a/src/commands/contract/interfaces.ts
+++ b/src/commands/contract/interfaces.ts
@@ -45,20 +45,26 @@ export function generateActionInterface(
         if (abiVariant) {
             types = abiVariant.types
 
-            variantType = `${struct.name}_${field.name}_variant`
-
             const variantTypeNodes = types.map((type) =>
                 ts.factory.createTypeReferenceNode(parseType(findExternalType(type, 'Types.', abi)))
             )
-            const variantTypeAlias = ts.factory.createTypeAliasDeclaration(
-                undefined,
+
+            const variantInterface = ts.factory.createInterfaceDeclaration(
                 [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-                variantType,
+                removeCommas(abiVariant.name),
                 undefined,
-                ts.factory.createUnionTypeNode(variantTypeNodes)
+                undefined,
+                [
+                    ts.factory.createPropertySignature(
+                        undefined,
+                        'value',
+                        undefined,
+                        ts.factory.createUnionTypeNode(variantTypeNodes)
+                    ),
+                ]
             )
 
-            typeInterfaces.push(variantTypeAlias)
+            typeInterfaces.push(variantInterface)
         } else {
             types = [field.type]
         }

--- a/src/commands/contract/structs.ts
+++ b/src/commands/contract/structs.ts
@@ -95,9 +95,9 @@ export function generateVariant(variant, abi: any, isExport = false): ts.ClassDe
     ]
 
     const valueField = ts.factory.createPropertyDeclaration(
-        [],
+        [ts.factory.createModifier(ts.SyntaxKind.DeclareKeyword)],
         ts.factory.createIdentifier('value'),
-        ts.factory.createToken(ts.SyntaxKind.ExclamationToken),
+        undefined,
         ts.factory.createUnionTypeNode(
             variant.fields.map((field) => {
                 return ts.factory.createTypeReferenceNode(

--- a/src/commands/contract/structs.ts
+++ b/src/commands/contract/structs.ts
@@ -171,12 +171,15 @@ export function generateField(
 ): ts.PropertyDeclaration {
     const fieldName = field.name
 
-    const isArray = field.type.endsWith('[]')
+    let isArray = field.type.endsWith('[]')
 
     // Start with the main type argument
     const decoratorArguments: (ts.ObjectLiteralExpression | ts.StringLiteral | ts.Identifier)[] = [
         findFieldStructType(field.type, namespace, abi),
     ]
+
+    const structTypeString = findFieldStructTypeString(field.type, namespace, abi)
+    isArray = isArray || structTypeString.endsWith('[]')
 
     // Build the options object if needed
     const optionsProps: ts.ObjectLiteralElementLike[] = []
@@ -214,8 +217,6 @@ export function generateField(
             )
         ),
     ]
-
-    const structTypeString = findFieldStructTypeString(field.type, namespace, abi)
 
     const typeReferenceNode = ts.factory.createTypeReferenceNode(
         extractDecorator(structTypeString).type

--- a/test/data/contracts/mock-atomicassets.ts
+++ b/test/data/contracts/mock-atomicassets.ts
@@ -103,31 +103,33 @@ export namespace ActionParams {
         }
         export interface pair_string_ATOMIC_ATTRIBUTE {
             key: string
-            value: Types.pair_string_ATOMIC_ATTRIBUTE_value_variant
+            value: Types.variant_int8_int16_int32_int64_uint8_uint16_uint32_uint64_float32_float64_string_INT8_VEC_INT16_VEC_INT32_VEC_INT64_VEC_UINT8_VEC_UINT16_VEC_UINT32_VEC_UINT64_VEC_FLOAT_VEC_DOUBLE_VEC_STRING_VEC
         }
-        export type pair_string_ATOMIC_ATTRIBUTE_value_variant =
-            | Int8Type
-            | Int16Type
-            | Int32Type
-            | Int64Type
-            | UInt8Type
-            | UInt16Type
-            | UInt32Type
-            | UInt64Type
-            | Float32Type
-            | Float64Type
-            | string
-            | BytesType
-            | Int16Type[]
-            | Int32Type[]
-            | Int64Type[]
-            | UInt8Type[]
-            | UInt16Type[]
-            | UInt32Type[]
-            | UInt64Type[]
-            | Float32Type[]
-            | Float64Type[]
-            | string[]
+        export interface variant_int8_int16_int32_int64_uint8_uint16_uint32_uint64_float32_float64_string_INT8_VEC_INT16_VEC_INT32_VEC_INT64_VEC_UINT8_VEC_UINT16_VEC_UINT32_VEC_UINT64_VEC_FLOAT_VEC_DOUBLE_VEC_STRING_VEC {
+            value:
+                | Int8Type
+                | Int16Type
+                | Int32Type
+                | Int64Type
+                | UInt8Type
+                | UInt16Type
+                | UInt32Type
+                | UInt64Type
+                | Float32Type
+                | Float64Type
+                | string
+                | BytesType
+                | Int16Type[]
+                | Int32Type[]
+                | Int64Type[]
+                | UInt8Type[]
+                | UInt16Type[]
+                | UInt32Type[]
+                | UInt64Type[]
+                | Float32Type[]
+                | Float64Type[]
+                | string[]
+        }
     }
     export interface acceptoffer {
         offer_id: UInt64Type
@@ -351,7 +353,7 @@ export namespace Types {
         ]
     )
     export class variant_int8_int16_int32_int64_uint8_uint16_uint32_uint64_float32_float64_string_INT8_VEC_INT16_VEC_INT32_VEC_INT64_VEC_UINT8_VEC_UINT16_VEC_UINT32_VEC_UINT64_VEC_FLOAT_VEC_DOUBLE_VEC_STRING_VEC extends Variant {
-        value!:
+        declare value:
             | Int8
             | Int16
             | Int32
@@ -529,8 +531,8 @@ export namespace Types {
         notify_accounts!: Name[]
         @Struct.field(Float64)
         market_fee!: Float64
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        data!: pair_string_ATOMIC_ATTRIBUTE[]
     }
     @Struct.type('createoffer')
     export class createoffer extends Struct {
@@ -570,8 +572,8 @@ export namespace Types {
         burnable!: boolean
         @Struct.field(UInt32)
         max_supply!: UInt32
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        immutable_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        immutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
     }
     @Struct.type('declineoffer')
     export class declineoffer extends Struct {
@@ -628,10 +630,10 @@ export namespace Types {
         template_id!: Int32
         @Struct.field(Asset, {array: true})
         backed_tokens!: Asset[]
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        old_immutable_data!: pair_string_ATOMIC_ATTRIBUTE
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        old_mutable_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        old_immutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        old_mutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
         @Struct.field(Name)
         asset_ram_payer!: Name
     }
@@ -649,14 +651,14 @@ export namespace Types {
         template_id!: Int32
         @Struct.field(Name)
         new_asset_owner!: Name
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        immutable_data!: pair_string_ATOMIC_ATTRIBUTE
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        mutable_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        immutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        mutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
         @Struct.field(Asset, {array: true})
         backed_tokens!: Asset[]
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        immutable_template_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        immutable_template_data!: pair_string_ATOMIC_ATTRIBUTE[]
     }
     @Struct.type('lognewoffer')
     export class lognewoffer extends Struct {
@@ -689,8 +691,8 @@ export namespace Types {
         burnable!: boolean
         @Struct.field(UInt32)
         max_supply!: UInt32
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        immutable_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        immutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
     }
     @Struct.type('logsetdata')
     export class logsetdata extends Struct {
@@ -698,10 +700,10 @@ export namespace Types {
         asset_owner!: Name
         @Struct.field(UInt64)
         asset_id!: UInt64
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        old_data!: pair_string_ATOMIC_ATTRIBUTE
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        new_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        old_data!: pair_string_ATOMIC_ATTRIBUTE[]
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        new_data!: pair_string_ATOMIC_ATTRIBUTE[]
     }
     @Struct.type('logtransfer')
     export class logtransfer extends Struct {
@@ -728,10 +730,10 @@ export namespace Types {
         template_id!: Int32
         @Struct.field(Name)
         new_asset_owner!: Name
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        immutable_data!: pair_string_ATOMIC_ATTRIBUTE
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        mutable_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        immutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        mutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
         @Struct.field(Asset, {array: true})
         tokens_to_back!: Asset[]
     }
@@ -788,15 +790,15 @@ export namespace Types {
         asset_owner!: Name
         @Struct.field(UInt64)
         asset_id!: UInt64
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        new_mutable_data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        new_mutable_data!: pair_string_ATOMIC_ATTRIBUTE[]
     }
     @Struct.type('setcoldata')
     export class setcoldata extends Struct {
         @Struct.field(Name)
         collection_name!: Name
-        @Struct.field(pair_string_ATOMIC_ATTRIBUTE)
-        data!: pair_string_ATOMIC_ATTRIBUTE
+        @Struct.field(pair_string_ATOMIC_ATTRIBUTE, {array: true})
+        data!: pair_string_ATOMIC_ATTRIBUTE[]
     }
     @Struct.type('setmarketfee')
     export class setmarketfee extends Struct {

--- a/test/data/contracts/mock-boid.ts
+++ b/test/data/contracts/mock-boid.ts
@@ -253,31 +253,33 @@ export namespace ActionParams {
         }
         export interface AtomicAttribute {
             key: string
-            value: Types.AtomicAttribute_value_variant
+            value: Types.AtomicValue
         }
-        export type AtomicAttribute_value_variant =
-            | Int8Type
-            | Int16Type
-            | Int32Type
-            | Int64Type
-            | UInt8Type
-            | UInt16Type
-            | UInt32Type
-            | UInt64Type
-            | Float32Type
-            | Float64Type
-            | string
-            | Int8Type[]
-            | Int16Type[]
-            | Int32Type[]
-            | Int64Type[]
-            | BytesType
-            | UInt16Type[]
-            | UInt32Type[]
-            | UInt64Type[]
-            | Float32Type[]
-            | Float64Type[]
-            | string[]
+        export interface AtomicValue {
+            value:
+                | Int8Type
+                | Int16Type
+                | Int32Type
+                | Int64Type
+                | UInt8Type
+                | UInt16Type
+                | UInt32Type
+                | UInt64Type
+                | Float32Type
+                | Float64Type
+                | string
+                | Int8Type[]
+                | Int16Type[]
+                | Int32Type[]
+                | Int64Type[]
+                | BytesType
+                | UInt16Type[]
+                | UInt32Type[]
+                | UInt64Type[]
+                | Float32Type[]
+                | Float64Type[]
+                | string[]
+        }
         export interface OfferRewards {
             nft_mints: Types.NftMint[]
             balance_deposit: UInt32Type
@@ -562,7 +564,7 @@ export namespace Types {
         'string[]',
     ])
     export class AtomicValue extends Variant {
-        value!:
+        declare value:
             | Int8
             | Int16
             | Int32

--- a/test/data/contracts/mock-eosio.ts
+++ b/test/data/contracts/mock-eosio.ts
@@ -183,7 +183,9 @@ export namespace ActionParams {
             producer_name: NameType
             block_signing_key: PublicKeyType
         }
-        export type regproducer2_producer_authority_variant = Types.block_signing_authority_v0
+        export interface variant_block_signing_authority_v0 {
+            value: Types.block_signing_authority_v0
+        }
         export interface block_signing_authority_v0 {
             threshold: UInt32Type
             keys: Types.key_weight[]
@@ -333,7 +335,7 @@ export namespace ActionParams {
     }
     export interface regproducer2 {
         producer: NameType
-        producer_authority: Types.regproducer2_producer_authority_variant
+        producer_authority: Types.variant_block_signing_authority_v0
         url: string
         location: UInt16Type
     }
@@ -486,7 +488,7 @@ export namespace Types {
     }
     @Variant.type('variant_block_signing_authority_v0', [block_signing_authority_v0])
     export class variant_block_signing_authority_v0 extends Variant {
-        value!: block_signing_authority_v0
+        declare value: block_signing_authority_v0
     }
     @Struct.type('abi_hash')
     export class abi_hash extends Struct {

--- a/test/data/contracts/mock-hegemon.hgm.ts
+++ b/test/data/contracts/mock-hegemon.hgm.ts
@@ -185,7 +185,7 @@ export namespace ActionParams {
             faction: UInt64Type
             base_faction_voting_power: Float64Type
             max_inventory_size: UInt32Type
-            inventory: Types.pair_uint32_uint64[]
+            inventory: Types.pair_uint32_uint64
             currency: AssetType
             last_respawn: TimePointType
             location_tile_id: UInt64Type
@@ -215,7 +215,7 @@ export namespace ActionParams {
     }
     export interface addinventory {
         player: NameType
-        ingredients: Types.pair_uint32_uint64[]
+        ingredients: Types.pair_uint32_uint64
     }
     export interface addmap {
         area_map: NameType
@@ -376,7 +376,7 @@ export namespace ActionParams {
     export interface dogive {
         owner: NameType
         recipient: NameType
-        items: Types.pair_uint32_uint64[]
+        items: Types.pair_uint32_uint64
     }
     export interface doheal {
         character_id: UInt64Type
@@ -506,7 +506,7 @@ export namespace ActionParams {
     }
     export interface setcrew {
         spaceship_id: UInt64Type
-        crew: Types.pair_uint64_CrewRole[]
+        crew: Types.pair_uint64_CrewRole
     }
     export interface setgm {
         player: NameType


### PR DESCRIPTION
1. added declare keyword for variant type value field.
2. Fixed variant interface, please note a variant is not a union type, it is a struct.
3. Fixed losing array decorator while following type alias
4. Added makefile command to update all mock contracts
5. Updated all mock contracts